### PR TITLE
Add normalize_values utility with validation and tests

### DIFF
--- a/src/normalize.py
+++ b/src/normalize.py
@@ -1,0 +1,31 @@
+import math
+
+def normalize_values(values, higher_is_better=True):
+    if not values:
+        return []
+
+    for value in values:
+        validate_number(value)
+
+    min_value = min(values)
+    max_value = max(values)
+
+    if min_value == max_value:
+        return [50.0] * len(values)
+
+    result = []
+    for value in values:
+        if higher_is_better:
+            result.append((value - min_value) / (max_value - min_value)*100)
+        else:
+            result.append((max_value - value) / (max_value - min_value)*100)
+
+    return result
+
+def validate_number(value):
+    if isinstance(value, bool):
+        raise ValueError("Value is boolean, number expected")
+    if not isinstance(value, (int, float)):
+        raise TypeError("All values must be integers or floats")
+    if math.isnan(value):
+        raise ValueError("Value is NaN")

--- a/tests/test_normalize_values.py
+++ b/tests/test_normalize_values.py
@@ -1,0 +1,28 @@
+import pytest
+from src.normalize import normalize_values
+
+def test_normalize_values_higher_is_better():
+    result = normalize_values([10, 544, 34.5, 90], higher_is_better=True)
+    assert result == pytest.approx([0, 100, 4.59, 14.98], abs=0.01)
+
+def test_normalize_values_lower_is_better():
+    result = normalize_values([10, 544, 34.5, 90], higher_is_better=False)
+    assert result == pytest.approx([100, 0, 95.39, 85.02], abs=0.03)
+
+def test_normalize_all_equal_values():
+    assert normalize_values([10, 10, 10, 10], higher_is_better=True) == [50, 50, 50, 50]
+
+def test_normalize_empty_values():
+    assert normalize_values([]) == []
+
+def test_normalize_invalid_type():
+    with pytest.raises(TypeError):
+        normalize_values([10, "30", 20, 50])
+
+def test_normalize_bool_is_invalid():
+    with pytest.raises(ValueError):
+        normalize_values([10, True, 29])
+
+def test_normalize_nan_is_invalid():
+    with pytest.raises(ValueError):
+        normalize_values([10, float("nan"), 29])


### PR DESCRIPTION
## Summary
Adds a `normalize_values` utility to scale numeric inputs to a 0-100 range.

## Changes
- added normalization for `higher_is_better=True`
- added inverted normalization for `higher_is_better=False`
- added validation for invalid types, booleans, and NaN
- added tests for normal cases and edge cases

## Tested
- higher is better
- lower is better
- all equal values
- empty input
- invalid type
- boolean input
- NaN input

Closes #3